### PR TITLE
fix template_obj.py for currency conversion properties.  not in a nic…

### DIFF
--- a/DigitalMeLib/data/schema/SchemaFactory.py
+++ b/DigitalMeLib/data/schema/SchemaFactory.py
@@ -135,9 +135,27 @@ class SchemaFactory(JSBASE):
         o.llist5.append(2)
         o.U = 1.1
         o.nr = 1
-        o.token_price = "10 EUR"
+        o.token_price = "10 USD"
         o.description = "something"
 
+
+        usd2usd = o.token_price_usd # convert USD-to-USD... same value
+        assert usd2usd == 10
+        inr = o.token_price_cur('inr')
+        #print ("convert 10 USD to INR", inr)
+        assert inr > 100 # ok INR is pretty high... check properly in a bit...
+        eur = o.token_price_eur
+        #print ("convert 10 USD to EUR", eur)
+        cureur = j.clients.currencylayer.cur2usd['eur']
+        curinr = j.clients.currencylayer.cur2usd['inr']
+        #print (cureur, curinr, o.token_price)
+        assert usd2usd*cureur == eur
+        assert usd2usd*curinr == inr
+
+        # try EUR to USD as well
+        o.token_price = "10 EUR"
+        eur2usd = o.token_price_usd
+        assert eur2usd*cureur == 10
 
         o._cobj
 

--- a/DigitalMeLib/data/schema/templates/template_obj.py
+++ b/DigitalMeLib/data/schema/templates/template_obj.py
@@ -79,16 +79,21 @@ class ModelOBJ():
     {% if prop.jumpscaletype.NAME == "numeric" %}
     @property 
     def {{prop.alias}}_usd(self):
-        return {{prop.js_typelocation}}.bytes2cur(self.{{prop.alias}})
+        return self.{{prop.alias}}_cur('usd')
     @property 
     def {{prop.alias}}_eur(self):
-        return {{prop.js_typelocation}}.bytes2cur(self.{{prop.alias}},curcode="eur")
+        return self.{{prop.alias}}_cur('eur')
 
     def {{prop.alias}}_cur(self,curcode):
         """
         @PARAM curcode e.g. usd, eur, egp, ...
         """
-        return {{prop.js_typelocation}}.bytes2cur(self.{{prop.alias}},curcode=curcode)
+        # cannot pass in string to bytes2cur, have to encode into packed first
+        strval = self.{{prop.alias}}
+        if isinstance(strval, bytes):
+            strval = strval.decode()
+        binval = {{prop.js_typelocation}}.str2bytes(strval)
+        return {{prop.js_typelocation}}.bytes2cur(binval,curcode=curcode)
     {% endif %}
 
     {% endfor %}

--- a/docs/jumpscale_schema/test1.py
+++ b/docs/jumpscale_schema/test1.py
@@ -34,12 +34,23 @@ o.nr = 1
 o.token_price = "10 EUR"
 o.description = "something"
 
-assert len(o._changed_items) > 3 #at least for properties, but prob also for the list?
+print ("after change")
+print(s)
+
+print ("token_price", repr(o.token_price))
+print ("_obj", dir(o._cobj))
+print ("_obj", dir(o._cobj.tokenPrice))
+print ("_schema", o._schema.property_token_price)
+print (dir(o._schema.property_token_price))
+print ("token_price_usd", repr(o.token_price_usd))
+print ("token_price_usd", type(o))
+assert o.token_price_usd <15
+
+# these fail (o._changed_list etc. don't exist)
 assert o._changed_list
 assert o._changed_properties
 
-assert o.token_price_usd <15  #tthere is error
-
+assert len(o._changed_items) > 3 #at least for properties, but prob also for the list?
 
 
 import bpython;bpython.embed(locals(), banner='test1')


### PR DESCRIPTION
…e way,

however there is not much of a choice.

the j.data.types.numeric.bytes2cur function requires PACKED BYTES
to be passed in... NOT a decoded (pretty-formatted) string like "10 USD".

so, as a work-around, the value is converted **TO** bytes (using
j.data.types.numeric.str2bytes) which is of course really inefficient
and THEN it can be passed in to the bytes2cur function.

really what should be happening is that instead of a string, a class
instance should be returned that points to the packed value, that
happens to have an __str__ (and/or __repr__) method.  although... having
a class instance is not particularly memory-efficient either...

unit tests have also been added.